### PR TITLE
PMM-9840 replace standard log to can use log level as part of issue PMM-7326

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/prometheus/common/log"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -142,7 +142,7 @@ func latestVersionFrom(apiList []string) string {
 		dateStr := apiVersionDate.FindString(api)
 		date, err := time.Parse(format, dateStr)
 		if err != nil {
-			log.Println(err)
+			log.Errorln(err)
 			continue
 		}
 
@@ -200,7 +200,7 @@ func (ac *AzureClient) getAccessToken() error {
 	var resp *http.Response
 	var err error
 	if len(sc.C.Credentials.ClientID) == 0 {
-		log.Printf("Using managed identity")
+		log.Infoln("Using managed identity")
 		target := fmt.Sprintf("http://169.254.169.254/metadata/identity/oauth2/token?resource=%s&api-version=2018-02-01", sc.C.ResourceManagerURL)
 		req, err := http.NewRequest("GET", target, nil)
 		if err != nil {

--- a/azure.go
+++ b/azure.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/common/log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/percona/azure_metrics_exporter/config"
+	"github.com/prometheus/common/log"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/golang/protobuf v1.3.3-0.20190827175835-822fe56949f5 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.6-0.20190917143953-de25ac347ef9 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
 	golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -60,6 +61,7 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.6-0.20190917143953-de25ac347ef9 h1:ZW4aXgUiOILOwNbYO7BEmuIb1SjpKjdfnbOZfehkxLo=
 github.com/prometheus/procfs v0.0.6-0.20190917143953-de25ac347ef9/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"github.com/prometheus/common/log"
 	"reflect"
 	"regexp"
 	"strings"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,32 +1,54 @@
 # github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+## explicit
 github.com/alecthomas/template
 github.com/alecthomas/template/parse
 # github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117
+## explicit
 github.com/alecthomas/units
 # github.com/beorn7/perks v1.0.1
+## explicit; go 1.11
 github.com/beorn7/perks/quantile
 # github.com/golang/protobuf v1.3.3-0.20190827175835-822fe56949f5
+## explicit; go 1.12
 github.com/golang/protobuf/proto
+# github.com/konsorten/go-windows-terminal-sequences v1.0.1
+## explicit
+github.com/konsorten/go-windows-terminal-sequences
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/prometheus/client_golang v1.1.1-0.20190913103102-20428fa0bffc
+## explicit; go 1.11
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
+## explicit; go 1.9
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.7.0
+## explicit; go 1.11
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
+github.com/prometheus/common/log
 github.com/prometheus/common/model
 github.com/prometheus/common/version
 # github.com/prometheus/procfs v0.0.6-0.20190917143953-de25ac347ef9
+## explicit
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/sirupsen/logrus v1.4.2
+## explicit
+github.com/sirupsen/logrus
 # golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13
+## explicit; go 1.12
+golang.org/x/sys/unix
 golang.org/x/sys/windows
+golang.org/x/sys/windows/registry
+golang.org/x/sys/windows/svc/eventlog
 # gopkg.in/alecthomas/kingpin.v2 v2.2.6
+## explicit
 gopkg.in/alecthomas/kingpin.v2
 # gopkg.in/yaml.v2 v2.2.2
+## explicit
 gopkg.in/yaml.v2


### PR DESCRIPTION
[PMM-9840](https://jira.percona.com/browse/PMM-9840) as part of issue [PMM-7326](https://jira.percona.com/browse/PMM-7326)

Build: [SUBMODULES-2443](https://github.com/Percona-Lab/pmm-submodules/pull/2443)

Did simple local test with:
```bash
./azure_metrics_exporter --log.level=info
./azure_metrics_exporter --log.level=error
./azure_metrics_exporter --log.level=undefined_log_level_expect_error_message
```

- [ ] https://github.com/percona/proxysql_exporter/pull/61
- [ ] https://github.com/percona/mysqld_exporter/pull/93